### PR TITLE
Adapted lore for PF1e and fixed character values

### DIFF
--- a/templates/parts/PF1e-Knowledge.html
+++ b/templates/parts/PF1e-Knowledge.html
@@ -1,0 +1,31 @@
+<div class='tab' data-tab='lore' data-group='party'>
+  <div class='table-row header'>
+      {{> 'modules/party-overview/templates/parts/FilterButton.html'}}
+      <div class='text'>{{localize 'party-overview.NAME'}}</div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKAr'}}"><i class='value fas fa-hand-sparkles'></i></div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKDu'}}"><i class='value fas fa-dungeon'></i></div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKEn'}}"><i class='value fas fa-cogs'></i></div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKGe'}}"><i class='value fas fa-map'></i></div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKHi'}}"><i class='value fas fa-landmark'></i></div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKLo'}}"><i class='value fas fa-address-book'></i></div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKNa'}}"><i class='value fas fa-leaf'></i></div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKNo'}}"><i class='value fas fa-crown'></i></div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKPl'}}"><i class='value fas fa-globe'></i></div>
+      <div class='num' style='flex: 1' title="{{localize 'PF1.SkillKRe'}}"><i class='value fas fa-place-of-worship'></i></div>
+  </div>
+
+  {{#each actors as | actor | }}
+  <div class='table-row'>
+      <div class='button'>
+          <button class='btn-toggle-visibility' data-actor='{{actor.id }}'>
+              {{#if actor.isHidden }}<i class='value fas fa-eye-slash'></i>{{else}}<i
+                  class='value fas fa-eye'></i>{{/if}}
+          </button>
+      </div>
+      <div class='text'>{{ actor.shortestName }}</div>
+      {{#each ../knowledges as | k | }}
+      <div class='num' style='flex: 1'>{{#if (lookup actor.knowledge @k)}}+{{lookup actor.knowledge @k}}{{else}}<i class='value fas fa-times' style='color: gray'></i>{{/if}}</div>
+      {{/each}}
+  </div>
+  {{/each}}
+</div>

--- a/templates/pf1.hbs
+++ b/templates/pf1.hbs
@@ -3,7 +3,7 @@
         <li class="item" data-tab="general">{{localize "party-overview.GENERAL"}}</li>
 		<li class="item" data-tab="currencies">{{localize "party-overview.WEALTH"}}</li>
 		<li class="item" data-tab="languages">{{localize "PF1.Languages"}}</li>
-		<li class="item" data-tab="lore">{{localize "PF1.SkillLor"}}</li>
+		<li class="item" data-tab="lore">{{localize "PF1.KnowledgeSkills"}}</li>
     </nav>
     <section class="content">
         <div class="tab" data-tab="general" data-group="party">
@@ -14,7 +14,7 @@
                 <div class="num" title="{{localize "PF1.ArmorClass"}}"><i class="fas fa-shield-alt"></i></div>
                 <div class="num" title="{{localize "PF1.SkillPer"}}"><i class="far fa-eye"></i></div>
                 <div class="num" title="{{localize "PF1.SavingThrowFort"}}"><i class="fas fa-hard-hat"></i></div>
-                <div class=" num" title="{{localize "PF1.SavingThrowRef"}}"><i class="fas fa-running"></i></div>
+                <div class="num" title="{{localize "PF1.SavingThrowRef"}}"><i class="fas fa-running"></i></div>
                 <div class="num" title="{{localize "PF1.SavingThrowWill"}}"><i class="fas fa-brain"></i></div>
             </div>
 
@@ -39,8 +39,8 @@
 		<!-- Languages -->
         {{> "modules/party-overview/templates/parts/Languages.html"}}
 
-        <!-- Lore -->
-        {{> "modules/party-overview/templates/parts/PF2e-Lore.html"}}
+        <!-- Knowledge -->
+        {{> "modules/party-overview/templates/parts/PF1e-Knowledge.html"}}
 
         <!-- Currency -->
         <div class="tab" data-tab="currencies" data-group="party">


### PR DESCRIPTION
This PR will change Lore to Knowledge for the Pathfinder 1 system, which are more useful (Lore is an optional rule), and also fix some values not showing correctely such as AC, and wealth (now also takes care of weightless currency).

![image](https://user-images.githubusercontent.com/30555419/133418117-ede86bbf-83fe-44f8-8f76-f3605b1f0953.png)
The new knowledge tab
