### PR TITLE
Fixed importing unloaded partial

### DIFF
--- a/templates/pf1.hbs
+++ b/templates/pf1.hbs
@@ -83,7 +83,7 @@
             </div>
         </div>
 
-        <!-- Lore -->
-        {{> "modules/party-overview/templates/parts/PF2e-Bulk.html"}}
+        <!-- Bulk -->
+        {{!-- {{> "modules/party-overview/templates/parts/PF2e-Bulk.html"}} --}}
     </section>
 </div>

--- a/templates/pf2e.hbs
+++ b/templates/pf2e.hbs
@@ -86,7 +86,7 @@
             </div>
         </div>
 
-        <!-- Lore -->
-        {{> "modules/party-overview/templates/parts/PF2e-Bulk.html"}}
+        <!-- Bulk -->
+        {{!-- {{> "modules/party-overview/templates/parts/PF2e-Bulk.html"}} --}}
     </section>
 </div>

--- a/templates/sfrpg.hbs
+++ b/templates/sfrpg.hbs
@@ -80,7 +80,7 @@
             </div>
         </div>
 
-        <!-- Lore -->
-        {{> "modules/party-overview/templates/parts/PF2e-Bulk.html"}}
+        <!-- Bulk -->
+        {{!-- {{> "modules/party-overview/templates/parts/PF2e-Bulk.html"}} --}}
     </section>
 </div>


### PR DESCRIPTION
Latest removed the loading of `PF2e-Bulk.html`, this caused an error because it was used in the other hbs files. I commented out these partials and now it should work. :-)

Error:
```
{
    "message": "An error occurred while rendering PartyOverviewApp 4: The partial modules/party-overview/templates/parts/PF2e-Bulk.html could not be found\n[No packages detected]",
    "name": "Error",
    "skip_package_detection": true
}
```