### PR TITLE
Rework the proficiency tab so that it displays more letters for the skills (dnd5e)

### DIFF
--- a/style/party-overview.css
+++ b/style/party-overview.css
@@ -144,3 +144,21 @@ button.party-overview-button.wfrp4e {
 button.party-overview-button:not(.wfrp4e) {
 	flex-basis: 100%;
 }
+
+.party-overview-window.dnd5e .proficiencies.tab .header .num {
+	flex: 1;
+}
+
+.party-overview-ellipsis {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: clip;
+}
+
+.party-overview-ellipsis {
+	border-right: 1px solid black;
+}
+
+.party-overview-ellipsis:last-child {
+	border-right: none;
+}

--- a/templates/parts/DND5E-Proficiencies.html
+++ b/templates/parts/DND5E-Proficiencies.html
@@ -1,9 +1,9 @@
-<div class="tab" data-tab="proficiencies" data-group="party">
+<div class="tab proficiencies" data-tab="proficiencies" data-group="party">
 	<div class="table-row header">
 		{{> "modules/party-overview/templates/parts/FilterButton.html"}}
 		<div class="text">{{localize "party-overview.NAME"}}</div>
 		{{#each skills as | s | }}
-		<div class="num" style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis">{{s}}</div>
+		<div class="num party-overview-ellipsis" title="{{s}}">{{s}}</div>
 		{{/each}}
 	</div>
 


### PR DESCRIPTION
Rework the proficiency tab so that it displays more than 1 letter of the skill.
    
- move styles into the css file to avoid using a style tag with a lot of repeating rules
- do not do "text-overflow: ellipsis" but "test-overflow: clip" otherwise most of the space is taken by the "..."
- add title="{{s}}" to the HTML so that we can see the full name of the skill when hovering

Before, the "..." takes a lot of room and skills are basically unreadable:
![party-overview-before](https://user-images.githubusercontent.com/1537446/149678031-3e84ddda-f081-4d78-a5c7-41596b6ba75c.png)

After, without the "..." we can show more letters, even with a smaller window:
![party-overview-after](https://user-images.githubusercontent.com/1537446/149678030-1fd0a56f-73e1-470c-ae0a-33ff5faaa908.png)

