### PR TITLE
Cyphersystem should only show 'pc' type

### DIFF
--- a/module/SystemProvider.js
+++ b/module/SystemProvider.js
@@ -1297,6 +1297,7 @@ export class cyphersystemProvider extends SystemProvider {
 
 	getActorDetails(actor) {
 		const data = actor.system;
+		if (actor.type!=='pc') return;
 		return {
 			id: actor.id,
 			name: actor.name,
@@ -1316,14 +1317,14 @@ export class cyphersystemProvider extends SystemProvider {
 			armorValueTotal: data.combat.armor.ratingTotal,
 			speedCostTotal: data.combat.armor.costTotal,
 			damageTrack: data.combat.damageTrack.state,
-		};
+		}
 	}
 
 	getUpdate(actors) {
 		return [
 			actors,
 			{
-				showAdditional: actors.some((actor) => actor.additionalPool.active),
+				showAdditional: actors.some((actor) => actor.type === 'pc' && actor.additionalPool.active),
 			},
 		];
 	}


### PR DESCRIPTION
This fixes a breaking issue when an NPC Actor (or other non-PC actor) is given Ownership to a player in the Cypher System.