### PR TITLE
Add actorFilter to cyphersystemProvider

### DIFF
--- a/module/SystemProvider.js
+++ b/module/SystemProvider.js
@@ -1303,6 +1303,10 @@ export class cyphersystemProvider extends SystemProvider {
 		return 700;
 	}
 
+	actorFilter(actor) {
+		return super.actorFilter(actor) && actor.type === "pc";
+	}
+
 	getActorDetails(actor) {
 		const data = actor.system;
 		if (actor.type!=='pc') return;


### PR DESCRIPTION
Add an actorFilter function to cyphersystemProvider so that the minimum window height is set correctly to only PCs owned by players, rather than all actors owned by players.