### PR TITLE
13th Age 2e icon benefit display

### DIFF
--- a/module/SystemProvider.js
+++ b/module/SystemProvider.js
@@ -110,6 +110,20 @@ export class archmageProvider extends SystemProvider {
 	}
 
 	getIcons(icons) {
+		const is2e = game.settings.get("archmage", "secondEdition");
+		const is2eAlt = game.settings.get("archmage", "alternateIconRollingMethod");
+		const resultCharacters = {
+			5: "5",
+			6: "6",
+		};
+		if (is2eAlt) {
+			delete resultCharacters[5];
+			resultCharacters[6] = "⨉";
+		} else if (is2e) {
+			resultCharacters[5] = "~";
+			resultCharacters[6] = "+";
+		}
+
 		const relationships = {
 			Positive: "+",
 			Negative: "-",
@@ -122,7 +136,7 @@ export class archmageProvider extends SystemProvider {
 				iconFilter[icons[icon].name.value] = {
 					bonus: icons[icon].bonus.value,
 					relationship: relationships[icons[icon].relationship.value],
-					results: icons[icon].results,
+					results: icons[icon].results.map(x => resultCharacters[x] || ''),
 				};
 			});
 		return iconFilter;

--- a/templates/archmage.hbs
+++ b/templates/archmage.hbs
@@ -67,7 +67,7 @@
                             {{#if this.results}}
                                 <ul class="flexrow" style="align-content: center; margin: 0; padding: 0;">
                                 {{#each this.results as | result | }}
-                                {{#if (gt result 0)}}<li class="po-archmage-icon">{{result}}</li>{{/if}}
+                                {{#if result}}<li class="po-archmage-icon">{{result}}</li>{{/if}}
                                 {{/each}}
                                 </ul>
                             {{/if}}


### PR DESCRIPTION
13th Age second edition is right around the corner, and it thinks of icon benefits a little differently. This checks the system settings and displays icon benefits the same way the main system does:

1e: shows `5` and `6`

> ![CleanShot 2025-06-01 at 17 34 25@2x](https://github.com/user-attachments/assets/79fdb80a-5da6-4845-bee4-bd14a11f342f)

2e standard: shows `+` (unused benefit, twist determined at cash-in) and `~` (unused benefit with an automatic twist)

> ![CleanShot 2025-06-01 at 17 34 55@2x](https://github.com/user-attachments/assets/0a205d8c-6de6-42d9-ba9f-e8c017a4765e)

2e alternate: shows `⨉` when a die is used up for the arc

> ![CleanShot 2025-06-01 at 17 35 33@2x](https://github.com/user-attachments/assets/65870bff-29ac-4b8c-9715-a1b8e115dead)
